### PR TITLE
test: verify stop_ray response content

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -474,6 +474,8 @@ class TestMain:
 
                 assert len(result) == 1
                 mock_manager.stop_cluster.assert_called_once()
+                response_data = json.loads(result[0].text)
+                assert response_data["status"] == "stopped"
 
     def test_run_server_function_exists(self):
         """Test that run_server function exists and is importable."""


### PR DESCRIPTION
## Summary
- ensure test_call_tool_stop_ray parses JSON and checks status

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_685c72a5cabc8329a0ba5198341bc7b3