### PR TITLE
Fix inconsistent isort config for lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,27 +40,27 @@ jobs:
         fail_ci_if_error: false
         verbose: true
 
-  # lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   
-  #   - name: Set up Python 3.10
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: "3.10"
-  #   
-  #   - name: Install uv
-  #     uses: astral-sh/setup-uv@v1
-  #     with:
-  #       version: "latest"
-  #   
-  #   - name: Install dependencies
-  #     run: uv sync --dev
-  #   
-  #   - name: Run linting
-  #     run: |
-  #       uv run black --check ray_mcp/ examples/ tests/ 
-  #       uv run isort --check-only ray_mcp/ examples/ tests/
-  #       uv run pyright ray_mcp/ examples/ tests/
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v1
+      with:
+        version: "latest"
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Run linting
+      run: |
+        uv run black --check ray_mcp/ examples/ tests/
+        uv run isort --check-only ray_mcp/ examples/ tests/
+        uv run pyright ray_mcp/ examples/ tests/
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ line_length = 88
 multi_line_output = 3
 combine_as_imports = true
 force_sort_within_sections = true
+known_third_party = ["mcp"]
 
 [tool.pyright]
 # Restrict analysis to this repository only

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -11,12 +11,11 @@ import tempfile
 import time
 from typing import Any, Dict, List, Optional
 
+from mcp.types import TextContent, Tool
 import psutil
 import pytest
 import pytest_asyncio
 import ray
-
-from mcp.types import TextContent, Tool
 
 # Import the MCP server functions directly for testing
 from ray_mcp.main import call_tool, list_tools

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,9 +6,9 @@ import json
 from typing import Any, Dict, List, cast
 from unittest.mock import AsyncMock, Mock, patch
 
+from mcp.types import TextContent, Tool
 import pytest
 
-from mcp.types import TextContent, Tool
 from ray_mcp.main import call_tool, list_tools
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,9 +8,9 @@ import sys
 from typing import Any, Dict, List, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+from mcp.types import TextContent
 import pytest
 
-from mcp.types import TextContent
 from ray_mcp.main import call_tool, list_tools, run_server
 
 


### PR DESCRIPTION
## Summary
- enable the lint job in CI again
- set `mcp` as a known third-party package for isort
- reorder test imports to satisfy new config

## Testing
- `make lint`
- `make test-fast` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_685c7a64bc248329a88a460e545e281f