### PR TITLE
Fix subprocess output handling

### DIFF
--- a/ray_mcp/worker_manager.py
+++ b/ray_mcp/worker_manager.py
@@ -144,7 +144,11 @@ class WorkerManager:
 
             # Start the process
             process = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=env,
+                text=True,
             )
 
             # Give it a moment to start


### PR DESCRIPTION
## Summary
- avoid pipe buffering when launching worker processes

## Testing
- `pytest -q` *(fails: unrecognized arguments `--cov`)*
- `pip install pytest-cov` *(fails: no internet access)*


------
https://chatgpt.com/codex/tasks/task_b_685cc1d72a94832997728573e3100f1b