### PR TITLE
Fix port selection in start_cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ For advanced configurations, you can specify custom worker nodes:
   }
 }
 ```
+The `head_node_port` is reused for both the GCS server and the Ray Client
+server. The `dashboard_port` controls the dashboard HTTP service.
 
 ### Basic Usage
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -53,8 +53,8 @@ Start a new Ray cluster with head node and worker nodes. **Defaults to multi-nod
       }
     }
   ],
-  "head_node_port": 10001,    // Port for head node (default: 10001)
-  "dashboard_port": 8265,     // Port for Ray dashboard (default: 8265)
+  "head_node_port": 10001,    // Port for head node (GCS & Ray Client)
+  "dashboard_port": 8265,     // Port for Ray dashboard
   "head_node_host": "127.0.0.1"  // Host address for head node (default: 127.0.0.1)
 }
 ```

--- a/ray_mcp/ray_manager.py
+++ b/ray_mcp/ray_manager.py
@@ -176,14 +176,15 @@ class RayManager:
                 import os
                 import subprocess
 
-                # Find a free port for the Ray Client server
-                ray_client_port = find_free_port(20000)
+                # Respect head_node_port argument when selecting ports
+                # Use the provided port if available, otherwise search for a free one
+                ray_client_port = find_free_port(head_node_port)
 
-                # Find a free port for the GCS server (start from ray_client_port + 1)
-                gcs_port = find_free_port(ray_client_port + 1)
+                # Use the same port for the GCS server
+                gcs_port = ray_client_port
 
-                # Find a free dashboard port
-                dashboard_port = find_free_port(8265)
+                # Find a free dashboard port starting from the provided dashboard_port
+                dashboard_port = find_free_port(dashboard_port)
 
                 # Build ray start command for head node
                 head_cmd = [


### PR DESCRIPTION
## Summary
- allow configuring head and dashboard ports in `RayManager.start_cluster`
- document port usage

## Testing
- `make test-fast` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_b_685cc1d3b94483299ae9560d866dc26e