### PR TITLE
Ignore cluster params when connecting

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -112,6 +112,9 @@ When no `worker_nodes` parameter is specified, the cluster will start with:
 - `ray://head-node-ip:10001`
 - `ray://cluster.example.com:10001`
 
+**Note:** When an address is provided, any cluster startup parameters such as
+`num_cpus`, `num_gpus`, or `object_store_memory` are ignored.
+
 ### cluster_info
 ```json
 {


### PR DESCRIPTION
## Summary
- skip startup parameters when `address` is provided to `start_cluster` or `connect_cluster`
- warn that the parameters are ignored and document it in docs
- test that `ray.init` receives no startup params when using an address

## Testing
- `black ray_mcp tests > /tmp/black.log && tail -n 20 /tmp/black.log`
- `isort ray_mcp tests > /tmp/isort.log && tail -n 20 /tmp/isort.log`
- `ruff check ray_mcp tests > /tmp/ruff.log && tail -n 20 /tmp/ruff.log`
- `pyright > /tmp/pyright.log && tail -n 20 /tmp/pyright.log`
- `pytest tests/test_ray_manager_methods.py::TestRayManagerMethods::test_start_cluster_with_address_filters_params -vv` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_685df08fc7348329a8f24bfb0fc29360