### PR TITLE
Improve job client initialization

### DIFF
--- a/ray_mcp/ray_manager.py
+++ b/ray_mcp/ray_manager.py
@@ -80,11 +80,16 @@ class RayManager:
             logger.error("JobSubmissionClient is not available")
             return None
 
+        loop = asyncio.get_running_loop()
+
         for attempt in range(max_retries):
             try:
-                job_client = JobSubmissionClient(address)
-                # Test the connection by doing a simple operation that requires the agent
-                job_client.list_jobs()
+                # Create the JobSubmissionClient in a thread to avoid blocking the event loop
+                job_client = await loop.run_in_executor(
+                    None, JobSubmissionClient, address
+                )
+                # Test the connection by calling list_jobs in the executor
+                await loop.run_in_executor(None, job_client.list_jobs)
                 logger.info(
                     f"Job client initialized successfully on attempt {attempt + 1}"
                 )


### PR DESCRIPTION
## Summary
- run JobSubmissionClient creation and list_jobs in executor
- test that the helper is async and uses executor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests')*
- `pytest -q -c /dev/null tests/test_ray_manager.py::TestRayManager::test_initialize_job_client_with_retry_executor -s` *(fails: async functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_b_685f66fd261483298845429871dad916