### PR TITLE
Fix job_inspect log parsing

### DIFF
--- a/ray_mcp/ray_manager.py
+++ b/ray_mcp/ray_manager.py
@@ -1221,6 +1221,7 @@ class RayManager:
         if not logs:
             return {"error_count": 0, "errors": [], "suggestions": []}
 
+        logs = str(logs)
         lines = logs.split("\n")
         error_lines = [
             line
@@ -1324,6 +1325,8 @@ class RayManager:
         """Generate debugging suggestions based on job info and logs."""
         suggestions = []
 
+        job_logs = str(job_logs) if job_logs is not None else ""
+
         if job_info.status == "FAILED":
             suggestions.append(
                 "Job failed. Check error logs for specific error messages."
@@ -1401,17 +1404,17 @@ class RayManager:
                         response["debug_info"] = {
                             "error_logs": [
                                 line
-                                for line in response.get("logs", "").split("\n")
+                                for line in str(response.get("logs", "")).split("\n")
                                 if "error" in line.lower()
                                 or "exception" in line.lower()
                             ],
                             "recent_logs": (
-                                response.get("logs", "").split("\n")[-20:]
+                                str(response.get("logs", "")).split("\n")[-20:]
                                 if response.get("logs")
                                 else []
                             ),
                             "debugging_suggestions": self._generate_debug_suggestions(
-                                job_info, response.get("logs", "")
+                                job_info, str(response.get("logs", ""))
                             ),
                         }
 
@@ -1456,16 +1459,16 @@ class RayManager:
                 response["debug_info"] = {
                     "error_logs": [
                         line
-                        for line in response.get("logs", "").split("\n")
+                        for line in str(response.get("logs", "")).split("\n")
                         if "error" in line.lower() or "exception" in line.lower()
                     ],
                     "recent_logs": (
-                        response.get("logs", "").split("\n")[-20:]
+                        str(response.get("logs", "")).split("\n")[-20:]
                         if response.get("logs")
                         else []
                     ),
                     "debugging_suggestions": self._generate_debug_suggestions(
-                        job_info, response.get("logs", "")
+                        job_info, str(response.get("logs", ""))
                     ),
                 }
 

--- a/tests/test_ray_manager.py
+++ b/tests/test_ray_manager.py
@@ -569,6 +569,34 @@ class TestRayManager:
         assert filtered["address"] == "ray://127.0.0.1:10001"
         assert filtered["custom_param"] == "should_be_passed"
 
+    @pytest.mark.asyncio
+    async def test_job_inspect_with_non_string_logs(self, initialized_manager):
+        """Ensure job_inspect handles non-string log data in debug mode."""
+        job_info = MagicMock()
+        job_info.status = "RUNNING"
+        job_info.entrypoint = "python app.py"
+        job_info.start_time = 0.0
+        job_info.end_time = None
+        job_info.metadata = {}
+        job_info.runtime_env = {}
+        job_info.message = ""
+
+        initialized_manager._job_client.get_job_info.return_value = job_info
+        initialized_manager._job_client.get_job_logs.return_value = [
+            "log line 1",
+            "error line",
+        ]
+
+        with patch("ray_mcp.ray_manager.RAY_AVAILABLE", True):
+            with patch("ray_mcp.ray_manager.ray") as mock_ray:
+                mock_ray.is_initialized.return_value = True
+
+                result = await initialized_manager.job_inspect("job_123", mode="debug")
+
+        assert result["status"] == "success"
+        assert result["inspection_mode"] == "debug"
+        assert "debug_info" in result
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- cast logs to str before splitting in RayManager
- expand debug suggestion helper to normalize log text
- add regression test feeding list data to job_inspect
- patch test to mock ray initialization

## Testing
- `make format`
- `make test-fast` *(fails: Fast test suite failed)*
- `uv run pytest tests/test_ray_manager.py::TestRayManager::test_job_inspect_with_non_string_logs -vv -s`

------
https://chatgpt.com/codex/tasks/task_b_685f671e43688329911f55cacd9223b9