### PR TITLE
fix tests for offline env

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and fixtures for Ray MCP tests."""
 
+import os
 import pytest
 
 from tests.test_utils import run_ray_cleanup, wait_for_ray_shutdown
@@ -7,6 +8,8 @@ from tests.test_utils import run_ray_cleanup, wait_for_ray_shutdown
 
 def pytest_configure(config):
     """Configure pytest with custom markers."""
+    # Disable Ray usage reporting to avoid network calls during tests
+    os.environ.setdefault("RAY_USAGE_STATS_ENABLED", "0")
     config.addinivalue_line("markers", "e2e: mark test as end-to-end integration test")
     config.addinivalue_line("markers", "slow: mark test as slow running")
     config.addinivalue_line("markers", "fast: mark test as fast running")


### PR DESCRIPTION
## Summary
- disable ray usage stats in pytest config so tests don't try to reach the network

## Testing
- `pyright`
- `pytest tests/test_main.py::TestMain::test_run_server_exists -q`

------
https://chatgpt.com/codex/tasks/task_b_6860269b6c6c83298ac6e4dc1825bc51