### PR TITLE
Replace print with logger in init_cluster

### DIFF
--- a/ray_mcp/ray_manager.py
+++ b/ray_mcp/ray_manager.py
@@ -351,7 +351,10 @@ class RayManager:
                 env = os.environ.copy()
                 env["RAY_DISABLE_USAGE_STATS"] = "1"
                 env["RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER"] = "1"
-                print(f"Starting head node with command: {' '.join(head_cmd)}")
+                logger.info(
+                    "Starting head node with command: %s",
+                    " ".join(head_cmd),
+                )
                 head_process = subprocess.Popen(
                     head_cmd,
                     stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- log the head node start command using logger.info instead of print
- ensure no direct print calls remain in production modules

## Testing
- `uv run pytest tests/ -k "not e2e" -q`

------
https://chatgpt.com/codex/tasks/task_b_6860555e03a0832991a8c8530cf9597b