### PR TITLE
Fix wildcard cleanup in ray_cleanup.sh

### DIFF
--- a/scripts/ray_cleanup.sh
+++ b/scripts/ray_cleanup.sh
@@ -61,11 +61,13 @@ cleanup_ray_dirs() {
         "/tmp/ray_cluster_*"
     )
     
-    for dir_pattern in "${ray_dirs[@]}"; do
-        if [ -d "$dir_pattern" ] 2>/dev/null; then
-            echo "🗑️  Removing Ray directory: $dir_pattern"
-            rm -rf "$dir_pattern" 2>/dev/null || true
-        fi
+    for pattern in "${ray_dirs[@]}"; do
+        for dir in $pattern; do
+            if [ -d "$dir" ] 2>/dev/null; then
+                echo "🗑️  Removing Ray directory: $dir"
+                rm -rf "$dir" 2>/dev/null || true
+            fi
+        done
     done
     
     # Also clean up any ray-related files in /tmp


### PR DESCRIPTION
## Summary
- expand globs in `cleanup_ray_dirs` to remove all matching dirs

## Testing
- `make lint`
- `make test-fast`


------
https://chatgpt.com/codex/tasks/task_b_68605555bf748329a6560f31a9d66c53