### PR TITLE
Fix init_cluster return key

### DIFF
--- a/ray_mcp/ray_manager.py
+++ b/ray_mcp/ray_manager.py
@@ -334,7 +334,7 @@ class RayManager:
                 return {
                     "status": "connected",
                     "message": f"Successfully connected to Ray cluster at {address}",
-                    "address": self._cluster_address,
+                    "cluster_address": self._cluster_address,
                     "dashboard_url": ray_context.dashboard_url,
                     "node_id": (
                         ray.get_runtime_context().get_node_id()

--- a/tests/test_ray_manager.py
+++ b/tests/test_ray_manager.py
@@ -109,7 +109,7 @@ class TestRayManager:
                 result = await ray_manager.init_cluster(address="ray://127.0.0.1:10001")
 
                 assert result["status"] == "connected"
-                assert "address" in result
+                assert "cluster_address" in result
                 assert result["dashboard_url"] == "http://127.0.0.1:8265"
                 assert result["node_id"] == "node_123"
                 assert result["session_name"] == "test_session"


### PR DESCRIPTION
## Summary
- return `cluster_address` from `init_cluster` when connecting
- update tests expecting the key

## Testing
- `PYTHONPATH=$(pwd) pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_6860b05a0cf8832993672c1e88223ff2