### PR TITLE
Remove unused imports

### DIFF
--- a/ray_mcp/tool_registry.py
+++ b/ray_mcp/tool_registry.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 from typing import Any, Callable, Dict, List, Optional, Union
-from unittest.mock import AsyncMock, Mock
 
 from mcp.types import Tool
 


### PR DESCRIPTION
## Summary
- clean up tool_registry by dropping unused mock imports

## Testing
- `make lint`
- `make test-fast`

------
https://chatgpt.com/codex/tasks/task_b_6860b05b0dd08329a46e68efe7b8ac7b