### PR TITLE
Fix inconsistent process state tracking in stop_cluster() (#63)

### DIFF
--- a/ray_mcp/ray_manager.py
+++ b/ray_mcp/ray_manager.py
@@ -983,21 +983,11 @@ class RayManager:
             head_stop_result = None
             if self._head_node_process is not None:
                 try:
-                    import subprocess
-
-                    # Use ray stop to properly stop the head node
-                    stop_cmd = ["ray", "stop"]
-                    stop_process = subprocess.run(
-                        stop_cmd, capture_output=True, text=True, timeout=10
-                    )
-                    if stop_process.returncode == 0:
-                        head_stop_result = "stopped"
-                    else:
-                        head_stop_result = f"error: {stop_process.stderr}"
+                    # Use the robust cleanup method that handles process state properly
+                    await self._cleanup_head_node_process(timeout=10)
+                    head_stop_result = "stopped"
                 except Exception as e:
                     head_stop_result = f"error: {str(e)}"
-                finally:
-                    self._head_node_process = None
 
             self._state_manager.reset_state()
 


### PR DESCRIPTION
- Replace manual subprocess.run() logic with existing _cleanup_head_node_process()
- Fixes issue where _head_node_process was set to None even on failed termination
- Update test_stop_cluster to mock _cleanup_head_node_process instead of subprocess
- Add test_stop_cluster_cleanup_failure_preserves_process_state to verify fix
- Ensures consistent process state management and better code reuse
- All tests pass