### PR TITLE
Fix race condition in port manager lock allocation (https://github.com/pradeepiyer/ray-mcp/issues/108)

### DIFF
--- a/ray_mcp/core/port_manager.py
+++ b/ray_mcp/core/port_manager.py
@@ -78,20 +78,26 @@ class RayPortManager(PortManager):
             return "."
 
     async def _try_allocate_port(self, port: int, temp_dir: str) -> bool:
-        """Try to allocate a specific port with file locking."""
+        """Try to allocate a specific port with atomic file locking."""
         lock_file_path = os.path.join(temp_dir, f"ray_port_{port}.lock")
 
-        # Check if port already has an active lock
-        if os.path.exists(lock_file_path):
-            if self._is_lock_active(lock_file_path):
-                return False
-            # Remove stale lock
-            self._remove_stale_lock(lock_file_path)
-
-        # Try to acquire exclusive lock and bind to port
+        # Try to acquire exclusive lock atomically
         try:
-            with open(lock_file_path, "w") as lock_file:
+            with open(lock_file_path, "a+") as lock_file:
+                # Acquire exclusive lock first (atomic operation)
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+                # Now that we have the lock, check if there's existing active content
+                lock_file.seek(0)
+                existing_content = lock_file.read().strip()
+
+                if existing_content and self._is_content_active_lock(existing_content):
+                    # Another process has an active lock, respect it
+                    return False
+
+                # Clear any stale content and try to bind to the port
+                lock_file.seek(0)
+                lock_file.truncate()
 
                 # Try to bind to the port while holding the lock
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -103,64 +109,41 @@ class RayPortManager(PortManager):
                         lock_file.flush()
                         return True
                     except OSError:
-                        # Port is in use
+                        # Port is in use by another service
                         return False
         except OSError:
             # Lock is held by another process or other error
             return False
 
-        # Clean up lock file if we didn't use the port
-        self._cleanup_unused_lock(lock_file_path)
-        return False
-
-    def _is_lock_active(self, lock_file_path: str) -> bool:
-        """Check if a lock file represents an active lock."""
-        try:
-            with open(lock_file_path, "r") as f:
-                content = f.read().strip()
-                if "," in content:
-                    pid_str, timestamp_str = content.split(",", 1)
-                    pid = int(pid_str)
-                    timestamp = int(timestamp_str)
-
-                    # Check if process still exists and lock is recent
-                    try:
-                        os.kill(pid, 0)  # Check if process exists
-                        return (
-                            int(time.time()) - timestamp
-                        ) < 300  # Less than 5 minutes old
-                    except OSError:
-                        # Process doesn't exist
-                        return False
-                else:
-                    # Old format, check file age
-                    stat = os.stat(lock_file_path)
-                    return (
-                        time.time() - stat.st_mtime
-                    ) < 300  # Less than 5 minutes old
-        except (OSError, IOError, ValueError):
+    def _is_content_active_lock(self, content: str) -> bool:
+        """Check if lock file content represents an active lock from another process."""
+        if not content:
             return False
 
-    def _remove_stale_lock(self, lock_file_path: str) -> None:
-        """Remove a stale lock file."""
         try:
-            os.unlink(lock_file_path)
-        except OSError:
-            pass
+            if "," in content:
+                pid_str, timestamp_str = content.split(",", 1)
+                pid = int(pid_str)
+                timestamp = int(timestamp_str)
 
-    def _cleanup_unused_lock(self, lock_file_path: str) -> None:
-        """Clean up lock file if we created it but didn't use the port."""
-        try:
-            if os.path.exists(lock_file_path):
-                # Only remove if we can acquire the lock (meaning no one else is using it)
-                with open(lock_file_path, "w") as f:
-                    try:
-                        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                        os.unlink(lock_file_path)
-                    except OSError:
-                        pass  # Someone else has the lock, leave the file
-        except (OSError, IOError):
-            pass  # Error cleaning up, not critical
+                # Don't consider our own process as blocking
+                if pid == os.getpid():
+                    return False
+
+                # Check if process still exists and lock is recent
+                try:
+                    os.kill(pid, 0)  # Check if process exists
+                    return (
+                        int(time.time()) - timestamp
+                    ) < 300  # Less than 5 minutes old
+                except OSError:
+                    # Process doesn't exist
+                    return False
+            else:
+                # Old format or invalid content, not an active lock
+                return False
+        except (ValueError, IndexError):
+            return False
 
     def _cleanup_stale_lock_files(self) -> None:
         """Clean up stale lock files from processes that no longer exist."""
@@ -170,7 +153,7 @@ class RayPortManager(PortManager):
             for filename in os.listdir(temp_dir):
                 if filename.startswith("ray_port_") and filename.endswith(".lock"):
                     lock_file_path = os.path.join(temp_dir, filename)
-                    if not self._is_lock_active(lock_file_path):
+                    if not self._is_lock_file_active(lock_file_path):
                         self._remove_stale_lock(lock_file_path)
                         LoggingUtility.log_info(
                             "port_allocation", f"Cleaned up stale lock file {filename}"
@@ -179,3 +162,19 @@ class RayPortManager(PortManager):
             LoggingUtility.log_warning(
                 "port_allocation", f"Error cleaning up stale lock files: {e}"
             )
+
+    def _is_lock_file_active(self, lock_file_path: str) -> bool:
+        """Check if a lock file represents an active lock."""
+        try:
+            with open(lock_file_path, "r") as f:
+                content = f.read().strip()
+                return self._is_content_active_lock(content)
+        except (OSError, IOError):
+            return False
+
+    def _remove_stale_lock(self, lock_file_path: str) -> None:
+        """Remove a stale lock file."""
+        try:
+            os.unlink(lock_file_path)
+        except OSError:
+            pass


### PR DESCRIPTION
Resolves #108 by making lock acquisition atomic:

- Remove TOCTOU race condition by acquiring lock first before checking for active content
- Change file open mode from 'w' to 'a+' to preserve existing content during lock acquisition
- Add logic to ignore locks from the same process (PID check)
- Refactor _is_lock_active into _is_content_active_lock and _is_lock_file_active for better separation
- Remove _cleanup_unused_lock method as it's no longer needed with atomic approach
- Add 2 focused tests for race condition scenarios:
  * test_race_condition_active_lock_respected - ensures active locks from other processes are respected
  * test_race_condition_own_process_ignored - ensures same process locks don't cause self-blocking

The fix ensures that lock file existence checks happen inside the critical section protected by fcntl.flock(), eliminating the window where multiple processes could simultaneously think a port is available.