### PR TITLE
fix: simplify complex process cleanup logic in WorkerManager

### DIFF
--- a/ray_mcp/worker_manager.py
+++ b/ray_mcp/worker_manager.py
@@ -339,17 +339,17 @@ class WorkerManager:
                 # Wait for graceful shutdown using non-blocking async wait
                 try:
                     loop = asyncio.get_running_loop()
-                    await loop.run_in_executor(None, lambda: process.wait(timeout=5))
+                    await asyncio.wait_for(
+                        loop.run_in_executor(None, process.wait), timeout=5
+                    )
                     status = "stopped"
                     message = f"Worker node '{node_name}' stopped gracefully"
-                except subprocess.TimeoutExpired:
+                except asyncio.TimeoutError:
                     # Force kill if it doesn't stop gracefully
                     process.kill()
-                    # Wait for force kill to complete with fallback zombie prevention
-                    status, message = (
-                        await self._wait_for_process_with_zombie_prevention(
-                            process, node_name, loop
-                        )
+                    # Wait for force kill to complete with simplified cleanup
+                    status, message = await self._wait_for_process_termination(
+                        process, node_name, 8
                     )
 
                 results.append(
@@ -380,129 +380,65 @@ class WorkerManager:
 
         return results
 
-    async def _wait_for_process_with_zombie_prevention(
-        self, process: subprocess.Popen, node_name: str, loop: asyncio.AbstractEventLoop
+    async def _wait_for_process_termination(
+        self, process: subprocess.Popen, node_name: str, timeout: int = 8
     ) -> Tuple[str, str]:
-        """Wait for process termination with zombie prevention.
+        """Wait for process termination with simplified robust cleanup.
 
-        Attempts multiple strategies to ensure the process is properly reaped
-        and doesn't become a zombie:
-        1. Standard wait with timeout
-        2. Non-blocking waitpid check
-        3. Repeated polling with exponential backoff
+        Uses Python's subprocess module and asyncio for proper process cleanup
+        without complex retry logic or busy-waiting.
 
         Args:
             process: The subprocess to wait for
             node_name: Name of the worker node for logging
-            loop: Event loop for async execution
+            timeout: Total timeout in seconds for process termination
 
         Returns:
             tuple[str, str]: (status, message) indicating the termination result
         """
+        pid = process.pid
+
         try:
-            # First attempt: normal wait with timeout
-            await loop.run_in_executor(None, lambda: process.wait(timeout=3))
+            # Use asyncio's process management for proper cleanup
+            # This automatically handles zombie prevention
+            loop = asyncio.get_running_loop()
+            await asyncio.wait_for(
+                loop.run_in_executor(None, process.wait), timeout=timeout
+            )
+
+            LoggingUtility.log_info(
+                "worker_manager",
+                f"Worker '{node_name}' (PID: {pid}) terminated successfully",
+            )
             return "force_stopped", f"Worker node '{node_name}' force stopped"
-        except subprocess.TimeoutExpired:
-            # Second attempt: use os.waitpid with WNOHANG for non-blocking check
-            try:
-                pid = process.pid
-                # Try non-blocking waitpid multiple times with backoff
-                for attempt in range(5):  # Try for up to ~3 more seconds
-                    try:
-                        result_pid, exit_status = await loop.run_in_executor(
-                            None, lambda: os.waitpid(pid, os.WNOHANG)
-                        )
-                        if result_pid == pid:
-                            # Process was successfully reaped
-                            LoggingUtility.log_info(
-                                "worker_manager",
-                                f"Worker '{node_name}' (PID: {pid}) reaped via waitpid after {attempt + 1} attempts",
-                            )
-                            return (
-                                "force_stopped",
-                                f"Worker node '{node_name}' force stopped",
-                            )
-                        elif result_pid == 0:
-                            # Process still running, wait and retry
-                            wait_time = 0.1 * (2**attempt)  # Exponential backoff
-                            await asyncio.sleep(wait_time)
-                        else:
-                            # Should not happen, but handle gracefully
-                            break
-                    except OSError as e:
-                        if e.errno == 3:  # ESRCH - No such process
-                            # Process already terminated and reaped
-                            LoggingUtility.log_info(
-                                "worker_manager",
-                                f"Worker '{node_name}' (PID: {pid}) already terminated and reaped",
-                            )
-                            return (
-                                "force_stopped",
-                                f"Worker node '{node_name}' force stopped",
-                            )
-                        else:
-                            # Other OS error, log and continue
-                            LoggingUtility.log_warning(
-                                "worker_manager",
-                                f"waitpid failed for worker '{node_name}' (PID: {pid}), attempt {attempt + 1}: {e}",
-                            )
 
-                # Final attempt: check if process is actually dead
-                try:
-                    # Send signal 0 to check if process exists
-                    await loop.run_in_executor(None, lambda: os.kill(pid, 0))
-                    # If we get here, process is still alive (shouldn't happen after SIGKILL)
-                    LoggingUtility.log_warning(
-                        "worker_manager",
-                        f"Worker '{node_name}' (PID: {pid}) still alive after force kill - may require system intervention",
-                    )
-                    return (
-                        "force_stopped",
-                        f"Worker node '{node_name}' force stopped (may still be running)",
-                    )
-                except OSError as e:
-                    if e.errno == 3:  # ESRCH - No such process
-                        # Process is dead, but we couldn't wait for it
-                        # This is the best we can do - process is terminated
-                        LoggingUtility.log_info(
-                            "worker_manager",
-                            f"Worker '{node_name}' (PID: {pid}) confirmed terminated",
-                        )
-                        return (
-                            "force_stopped",
-                            f"Worker node '{node_name}' force stopped",
-                        )
-                    else:
-                        # Permission denied or other error
-                        LoggingUtility.log_warning(
-                            "worker_manager",
-                            f"Cannot verify termination of worker '{node_name}' (PID: {pid}): {e}",
-                        )
-                        return (
-                            "force_stopped",
-                            f"Worker node '{node_name}' force stopped (status unknown)",
-                        )
-
-            except Exception as cleanup_error:
-                LoggingUtility.log_error(
+        except asyncio.TimeoutError:
+            # Process didn't terminate within timeout
+            # Check if it's actually still running
+            if process.poll() is None:
+                LoggingUtility.log_warning(
                     "worker_manager",
-                    Exception(
-                        f"Failed to clean up worker '{node_name}' (PID: {process.pid}): {cleanup_error}"
-                    ),
+                    f"Worker '{node_name}' (PID: {pid}) did not terminate within {timeout}s",
                 )
                 return (
                     "force_stopped",
-                    f"Worker node '{node_name}' force stopped (cleanup failed)",
+                    f"Worker node '{node_name}' force stopped (may still be running)",
                 )
-        except Exception as wait_error:
+            else:
+                # Process actually terminated but we missed it
+                LoggingUtility.log_info(
+                    "worker_manager",
+                    f"Worker '{node_name}' (PID: {pid}) terminated (detected late)",
+                )
+                return "force_stopped", f"Worker node '{node_name}' force stopped"
+
+        except Exception as e:
+            # Unexpected error during cleanup
             LoggingUtility.log_error(
                 "worker_manager",
-                Exception(
-                    f"Unexpected error waiting for worker '{node_name}' (PID: {process.pid}): {wait_error}"
-                ),
+                Exception(f"Error waiting for worker '{node_name}' (PID: {pid}): {e}"),
             )
             return (
                 "force_stopped",
-                f"Worker node '{node_name}' force stopped (wait failed)",
+                f"Worker node '{node_name}' force stopped (cleanup error)",
             )

--- a/tests/test_core_unified_manager.py
+++ b/tests/test_core_unified_manager.py
@@ -3,6 +3,7 @@
 Tests focus on unified facade behavior with 100% mocking.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -445,3 +446,122 @@ class TestRayUnifiedManagerStateConsistency:
                     assert manager_value is True
                 else:
                     assert manager_value == mock_state[property_name]
+
+
+@pytest.mark.fast
+class TestWorkerManagerProcessCleanup:
+    """Test the simplified process cleanup logic in WorkerManager."""
+
+    @pytest.fixture
+    def worker_manager(self):
+        """Create a WorkerManager instance for testing."""
+        from ray_mcp.worker_manager import WorkerManager
+
+        return WorkerManager()
+
+    async def test_process_termination_scenarios(self, worker_manager):
+        """Test multiple scenarios for the simplified process termination logic."""
+        from unittest.mock import AsyncMock, Mock
+
+        # Test 1: Successful termination
+        mock_process = Mock()
+        mock_process.pid = 12345
+        mock_process.wait = Mock(return_value=0)
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
+            
+            status, message = await worker_manager._wait_for_process_termination(
+                mock_process, "test-worker", timeout=5
+            )
+            
+            assert status == "force_stopped"
+            assert "test-worker" in message
+            assert "force stopped" in message
+
+        # Test 2: Timeout but process actually terminated (race condition)
+        mock_process.poll.return_value = 0  # Process is terminated
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(
+                side_effect=asyncio.TimeoutError()
+            )
+            
+            status, message = await worker_manager._wait_for_process_termination(
+                mock_process, "test-worker", timeout=5
+            )
+            
+            assert status == "force_stopped"
+            assert "test-worker" in message
+
+        # Test 3: Timeout with process still running
+        mock_process.poll.return_value = None  # Process still running
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(
+                side_effect=asyncio.TimeoutError()
+            )
+            
+            status, message = await worker_manager._wait_for_process_termination(
+                mock_process, "test-worker", timeout=5
+            )
+            
+            assert status == "force_stopped"
+            assert "may still be running" in message
+
+        # Test 4: Unexpected exception during cleanup
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(
+                side_effect=RuntimeError("Unexpected error")
+            )
+            
+            status, message = await worker_manager._wait_for_process_termination(
+                mock_process, "test-worker", timeout=5
+            )
+            
+            assert status == "force_stopped"
+            assert "cleanup error" in message
+
+    async def test_stop_all_workers_graceful_and_force_termination(self, worker_manager):
+        """Test both graceful and force termination workflows in stop_all_workers."""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Test graceful termination first
+        mock_process_graceful = Mock()
+        mock_process_graceful.pid = 12345
+        mock_process_graceful.terminate = Mock()
+        mock_process_graceful.wait = Mock(return_value=0)
+
+        worker_manager.worker_processes = [mock_process_graceful]
+        worker_manager.worker_configs = [{"node_name": "graceful-worker"}]
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
+
+            results = await worker_manager.stop_all_workers()
+
+            assert len(results) == 1
+            assert results[0]["status"] == "stopped"
+            assert results[0]["node_name"] == "graceful-worker"
+            assert "stopped gracefully" in results[0]["message"]
+            assert len(worker_manager.worker_processes) == 0
+
+        # Test force termination when graceful fails
+        mock_process_force = Mock()
+        mock_process_force.pid = 54321
+        mock_process_force.terminate = Mock()
+        mock_process_force.kill = Mock()
+        mock_process_force.wait = Mock(return_value=0)
+
+        worker_manager.worker_processes = [mock_process_force]
+        worker_manager.worker_configs = [{"node_name": "force-worker"}]
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
+            
+            # First asyncio.wait_for (graceful) times out, triggering force termination
+            with patch("asyncio.wait_for", side_effect=[asyncio.TimeoutError(), None]):
+                results = await worker_manager.stop_all_workers()
+
+                assert len(results) == 1
+                assert results[0]["status"] == "force_stopped"
+                assert results[0]["node_name"] == "force-worker"
+                assert len(worker_manager.worker_processes) == 0

--- a/tests/test_core_unified_manager.py
+++ b/tests/test_core_unified_manager.py
@@ -470,11 +470,11 @@ class TestWorkerManagerProcessCleanup:
 
         with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
-            
+
             status, message = await worker_manager._wait_for_process_termination(
                 mock_process, "test-worker", timeout=5
             )
-            
+
             assert status == "force_stopped"
             assert "test-worker" in message
             assert "force stopped" in message
@@ -485,11 +485,11 @@ class TestWorkerManagerProcessCleanup:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 side_effect=asyncio.TimeoutError()
             )
-            
+
             status, message = await worker_manager._wait_for_process_termination(
                 mock_process, "test-worker", timeout=5
             )
-            
+
             assert status == "force_stopped"
             assert "test-worker" in message
 
@@ -499,11 +499,11 @@ class TestWorkerManagerProcessCleanup:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 side_effect=asyncio.TimeoutError()
             )
-            
+
             status, message = await worker_manager._wait_for_process_termination(
                 mock_process, "test-worker", timeout=5
             )
-            
+
             assert status == "force_stopped"
             assert "may still be running" in message
 
@@ -512,15 +512,17 @@ class TestWorkerManagerProcessCleanup:
             mock_loop.return_value.run_in_executor = AsyncMock(
                 side_effect=RuntimeError("Unexpected error")
             )
-            
+
             status, message = await worker_manager._wait_for_process_termination(
                 mock_process, "test-worker", timeout=5
             )
-            
+
             assert status == "force_stopped"
             assert "cleanup error" in message
 
-    async def test_stop_all_workers_graceful_and_force_termination(self, worker_manager):
+    async def test_stop_all_workers_graceful_and_force_termination(
+        self, worker_manager
+    ):
         """Test both graceful and force termination workflows in stop_all_workers."""
         from unittest.mock import AsyncMock, Mock, patch
 
@@ -556,7 +558,7 @@ class TestWorkerManagerProcessCleanup:
 
         with patch("asyncio.get_running_loop") as mock_loop:
             mock_loop.return_value.run_in_executor = AsyncMock(return_value=0)
-            
+
             # First asyncio.wait_for (graceful) times out, triggering force termination
             with patch("asyncio.wait_for", side_effect=[asyncio.TimeoutError(), None]):
                 results = await worker_manager.stop_all_workers()


### PR DESCRIPTION
Addresses issue #109 by replacing the overly complex process cleanup logic with a robust, simplified implementation:

- Removed complex nested exception handlers that could mask real issues
- Eliminated busy-wait loop using os.waitpid() with WNOHANG and exponential backoff
- Simplified timeout handling using asyncio.wait_for instead of manual retry logic
- Added 2 comprehensive tests covering all scenarios for easier maintenance
- Maintained same functionality while improving reliability and maintainability

The new implementation uses Python's subprocess module and asyncio for proper process cleanup, automatically handling zombie prevention without complex retry mechanisms.

Fixes #109