### PR TITLE
Fix memory issue in log processing - streaming approach

### DIFF
--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -26,9 +26,17 @@ class TestMCPServer:
         with patch("ray_mcp.main.RAY_AVAILABLE", False):
             # Should not exit when Ray is not available, just log warning
             with patch("ray_mcp.main.stdio_server") as mock_stdio:
-                mock_stdio.return_value.__aenter__.return_value = (Mock(), Mock())
-                with patch("ray_mcp.main.server.run") as mock_run:
-                    mock_run.return_value = None
+                # Use AsyncMock for the streams since they're used in async context
+                mock_read_stream = AsyncMock()
+                mock_write_stream = AsyncMock()
+                mock_stdio.return_value.__aenter__.return_value = (
+                    mock_read_stream,
+                    mock_write_stream,
+                )
+
+                with patch(
+                    "ray_mcp.main.server.run", new_callable=AsyncMock
+                ) as mock_run:
                     # Should not raise SystemExit
                     from ray_mcp.main import main
 


### PR DESCRIPTION
- Replace string.split() with character-by-character streaming to prevent memory exhaustion when processing very large log strings
- Add _stream_log_lines generator method for memory-efficient line processing
- Update stream_logs_with_pagination to use estimation for very large logs (>10MB)
- Add comprehensive test suite for memory-efficient log processing
- Maintains backward compatibility and existing API
- Addresses issue #110