### PR TITLE
Fix worker process cleanup to prevent zombie processes

### DIFF
--- a/ray_mcp/kubernetes/crds/ray_job_crd.py
+++ b/ray_mcp/kubernetes/crds/ray_job_crd.py
@@ -261,54 +261,76 @@ class RayJobCRDManager(BaseCRDManager):
         """Format runtime environment as YAML string with smart defaults."""
         # Create a copy to avoid modifying the original
         processed_env = runtime_env.copy()
-        
+
         # Handle working_dir to prevent large uploads
         if "working_dir" in processed_env:
             working_dir = processed_env["working_dir"]
-            
+
             # If working_dir is "." (current directory), add comprehensive excludes
             if working_dir == ".":
                 excludes = processed_env.get("excludes", [])
-                
+
                 # Add default excludes to prevent large file uploads
                 default_excludes = [
                     # Ray and Python binaries
-                    "**/*.so", "**/*.so.*", "**/*.whl", "**/*.jar",
-                    "**/bin/python*", "**/lib/libpython*", "**/lib/libstdc++*",
-                    
-                    # Conda/Anaconda directories  
-                    "anaconda3/**", "miniconda3/**", ".conda/**",
-                    "**/site-packages/ray/**", "**/site-packages/numpy/**",
-                    "**/site-packages/scipy/**", "**/site-packages/pandas/**",
-                    "**/site-packages/torch/**", "**/site-packages/tensorflow/**",
-                    
+                    "**/*.so",
+                    "**/*.so.*",
+                    "**/*.whl",
+                    "**/*.jar",
+                    "**/bin/python*",
+                    "**/lib/libpython*",
+                    "**/lib/libstdc++*",
+                    # Conda/Anaconda directories
+                    "anaconda3/**",
+                    "miniconda3/**",
+                    ".conda/**",
+                    "**/site-packages/ray/**",
+                    "**/site-packages/numpy/**",
+                    "**/site-packages/scipy/**",
+                    "**/site-packages/pandas/**",
+                    "**/site-packages/torch/**",
+                    "**/site-packages/tensorflow/**",
                     # Package caches and builds
-                    "**/__pycache__/**", "**/.pyc", "**/build/**", "**/dist/**",
-                    "**/.git/**", "**/.pytest_cache/**", "**/.tox/**",
-                    
+                    "**/__pycache__/**",
+                    "**/.pyc",
+                    "**/build/**",
+                    "**/dist/**",
+                    "**/.git/**",
+                    "**/.pytest_cache/**",
+                    "**/.tox/**",
                     # Large ML/Data files
-                    "**/models/**", "**/data/**", "**/datasets/**", "**/*.pkl",
-                    "**/*.h5", "**/*.hdf5", "**/*.npy", "**/*.npz",
-                    
+                    "**/models/**",
+                    "**/data/**",
+                    "**/datasets/**",
+                    "**/*.pkl",
+                    "**/*.h5",
+                    "**/*.hdf5",
+                    "**/*.npy",
+                    "**/*.npz",
                     # Documentation and logs
-                    "**/docs/**", "**/logs/**", "**/*.log", "**/*.md"
+                    "**/docs/**",
+                    "**/logs/**",
+                    "**/*.log",
+                    "**/*.md",
                 ]
-                
+
                 # Merge with existing excludes, avoiding duplicates
                 all_excludes = list(set(excludes + default_excludes))
                 processed_env["excludes"] = all_excludes
-                
+
                 self._LoggingUtility.log_info(
                     "runtime_env_processing",
-                    f"Added {len(default_excludes)} default excludes for working_dir='.' to prevent large uploads"
+                    f"Added {len(default_excludes)} default excludes for working_dir='.' to prevent large uploads",
                 )
-        
+
         try:
             import yaml
+
             return yaml.dump(processed_env, default_flow_style=False)
         except ImportError:
             # Fallback to JSON if YAML not available
             import json
+
             return json.dumps(processed_env)
 
     def _build_submitter_pod_template(self, **kwargs: Any) -> Dict[str, Any]:

--- a/ray_mcp/managers/cluster_manager.py
+++ b/ray_mcp/managers/cluster_manager.py
@@ -733,11 +733,11 @@ class ClusterManager(ResourceManager, ManagedComponent):
         self, process: subprocess.Popen, node_name: str
     ) -> Dict[str, Any]:
         """Safely terminate a process and ensure proper cleanup.
-        
+
         The key insight: always call wait() after terminate() to prevent zombies.
         """
         process_id = process.pid
-        
+
         try:
             # If process is already dead, we're done
             if process.poll() is not None:
@@ -747,11 +747,11 @@ class ClusterManager(ResourceManager, ManagedComponent):
                     "message": f"Worker '{node_name}' was already stopped",
                     "process_id": process_id,
                 }
-            
+
             # Try graceful termination first
             process.terminate()
             loop = asyncio.get_running_loop()
-            
+
             try:
                 await asyncio.wait_for(
                     loop.run_in_executor(None, process.wait), timeout=5
@@ -774,7 +774,7 @@ class ClusterManager(ResourceManager, ManagedComponent):
                     "message": f"Worker '{node_name}' force stopped",
                     "process_id": process_id,
                 }
-        
+
         except Exception as e:
             # If anything goes wrong, ensure we still wait() for the process
             try:
@@ -784,7 +784,7 @@ class ClusterManager(ResourceManager, ManagedComponent):
                     await loop.run_in_executor(None, process.wait)
             except Exception:
                 pass  # We tried our best
-            
+
             return {
                 "status": "error",
                 "node_name": node_name,

--- a/ray_mcp/managers/cluster_manager.py
+++ b/ray_mcp/managers/cluster_manager.py
@@ -729,57 +729,77 @@ class ClusterManager(ResourceManager, ManagedComponent):
             self._LoggingUtility.log_error("spawn worker process", e)
             return None
 
+    async def _safely_terminate_process(
+        self, process: subprocess.Popen, node_name: str
+    ) -> Dict[str, Any]:
+        """Safely terminate a process and ensure proper cleanup.
+        
+        The key insight: always call wait() after terminate() to prevent zombies.
+        """
+        process_id = process.pid
+        
+        try:
+            # If process is already dead, we're done
+            if process.poll() is not None:
+                return {
+                    "status": "stopped",
+                    "node_name": node_name,
+                    "message": f"Worker '{node_name}' was already stopped",
+                    "process_id": process_id,
+                }
+            
+            # Try graceful termination first
+            process.terminate()
+            loop = asyncio.get_running_loop()
+            
+            try:
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, process.wait), timeout=5
+                )
+                return {
+                    "status": "stopped",
+                    "node_name": node_name,
+                    "message": f"Worker '{node_name}' stopped gracefully",
+                    "process_id": process_id,
+                }
+            except asyncio.TimeoutError:
+                # Force kill if graceful shutdown times out
+                process.kill()
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, process.wait), timeout=3
+                )
+                return {
+                    "status": "force_stopped",
+                    "node_name": node_name,
+                    "message": f"Worker '{node_name}' force stopped",
+                    "process_id": process_id,
+                }
+        
+        except Exception as e:
+            # If anything goes wrong, ensure we still wait() for the process
+            try:
+                if process.poll() is None:  # Still alive
+                    process.kill()
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(None, process.wait)
+            except Exception:
+                pass  # We tried our best
+            
+            return {
+                "status": "error",
+                "node_name": node_name,
+                "message": f"Error stopping worker '{node_name}': {str(e)}",
+                "process_id": process_id,
+            }
+
     async def _stop_all_workers(self) -> List[Dict[str, Any]]:
         """Stop all worker nodes with simplified cleanup."""
         results = []
 
         for i, process in enumerate(self._worker_processes):
-            try:
-                node_name = self._worker_configs[i].get("node_name", f"worker-{i+1}")
-
-                # Terminate process
-                process.terminate()
-
-                # Wait for graceful shutdown
-                try:
-                    loop = asyncio.get_running_loop()
-                    await asyncio.wait_for(
-                        loop.run_in_executor(None, process.wait), timeout=5
-                    )
-                    status = "stopped"
-                    message = f"Worker '{node_name}' stopped gracefully"
-                except asyncio.TimeoutError:
-                    # Force kill
-                    process.kill()
-                    try:
-                        await asyncio.wait_for(
-                            loop.run_in_executor(None, process.wait), timeout=3
-                        )
-                        status = "force_stopped"
-                        message = f"Worker '{node_name}' force stopped"
-                    except asyncio.TimeoutError:
-                        status = "force_stopped"
-                        message = (
-                            f"Worker '{node_name}' force stopped (may still be running)"
-                        )
-
-                results.append(
-                    {
-                        "status": status,
-                        "node_name": node_name,
-                        "message": message,
-                        "process_id": process.pid,
-                    }
-                )
-
-            except Exception as e:
-                results.append(
-                    {
-                        "status": "error",
-                        "node_name": f"worker-{i+1}",
-                        "message": f"Error stopping worker: {str(e)}",
-                    }
-                )
+            node_name = self._worker_configs[i].get("node_name", f"worker-{i+1}")
+            result = await self._safely_terminate_process(process, node_name)
+            results.append(result)
 
         # Clear worker tracking
         self._worker_processes.clear()

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -423,6 +423,181 @@ class TestManagerResourceHandling:
         mock_ray.shutdown.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_worker_process_cleanup_safe_termination(self):
+        """Test that worker processes are properly cleaned up even when exceptions occur."""
+        from ray_mcp.managers.port_manager import PortManager
+
+        state_manager = StateManager()
+        port_manager = PortManager()
+        cluster_manager = ClusterManager(state_manager, port_manager)
+
+        # Create mock processes
+        mock_process1 = Mock()
+        mock_process1.pid = 1234
+        mock_process1.poll.return_value = None  # Process is alive
+        mock_process1.terminate = Mock()
+        mock_process1.wait = Mock()
+
+        mock_process2 = Mock()
+        mock_process2.pid = 5678
+        mock_process2.poll.return_value = None  # Process is alive
+        mock_process2.terminate = Mock(side_effect=Exception("Terminate failed"))
+        mock_process2.kill = Mock()
+        mock_process2.wait = Mock()
+
+        # Set up worker processes and configs
+        cluster_manager._worker_processes = [mock_process1, mock_process2]
+        cluster_manager._worker_configs = [
+            {"node_name": "worker-1"},
+            {"node_name": "worker-2"},
+        ]
+
+        # Test graceful shutdown for first process
+        with (
+            patch("asyncio.get_running_loop") as mock_loop,
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_loop.return_value = asyncio.get_running_loop()
+            mock_wait_for.return_value = None  # Simulate successful wait
+
+            result = await cluster_manager._safely_terminate_process(
+                mock_process1, "worker-1"
+            )
+
+            assert result["status"] == "stopped"
+            assert result["node_name"] == "worker-1"
+            assert "stopped gracefully" in result["message"]
+            mock_process1.terminate.assert_called_once()
+            mock_wait_for.assert_called_once()
+
+        # Test exception during termination for second process
+        with (
+            patch("asyncio.get_running_loop") as mock_loop,
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_loop.return_value = asyncio.get_running_loop()
+            mock_executor = Mock()
+            mock_loop.return_value.run_in_executor = mock_executor
+            mock_executor.return_value = None  # Simulate successful wait after kill
+
+            result = await cluster_manager._safely_terminate_process(
+                mock_process2, "worker-2"
+            )
+
+            assert result["status"] == "error"
+            assert result["node_name"] == "worker-2"
+            assert "Error stopping worker" in result["message"]
+            # Verify that despite the exception, kill() and run_in_executor were called
+            mock_process2.kill.assert_called_once()
+            mock_executor.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_process_cleanup_timeout_handling(self):
+        """Test that worker process cleanup handles timeouts correctly."""
+        from ray_mcp.managers.port_manager import PortManager
+
+        state_manager = StateManager()
+        port_manager = PortManager()
+        cluster_manager = ClusterManager(state_manager, port_manager)
+
+        # Create mock process that times out on graceful shutdown
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll.return_value = None  # Process is alive
+        mock_process.terminate = Mock()
+        mock_process.kill = Mock()
+        mock_process.wait = Mock()
+
+        with (
+            patch("asyncio.get_running_loop") as mock_loop,
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_loop.return_value = asyncio.get_running_loop()
+            # First wait_for (terminate) times out, second (kill) succeeds
+            mock_wait_for.side_effect = [asyncio.TimeoutError(), None]
+
+            result = await cluster_manager._safely_terminate_process(
+                mock_process, "worker-test"
+            )
+
+            assert result["status"] == "force_stopped"
+            assert result["node_name"] == "worker-test"
+            assert "force stopped" in result["message"]
+            mock_process.terminate.assert_called_once()
+            mock_process.kill.assert_called_once()
+            # wait_for should be called twice (once for terminate, once for kill)
+            assert mock_wait_for.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_all_workers_integration(self):
+        """Test the complete _stop_all_workers method with mixed scenarios."""
+        from ray_mcp.managers.port_manager import PortManager
+
+        state_manager = StateManager()
+        port_manager = PortManager()
+        cluster_manager = ClusterManager(state_manager, port_manager)
+
+        # Create mock processes with different behaviors
+        mock_process1 = Mock()
+        mock_process1.pid = 1234
+        mock_process1.poll.return_value = None  # Process is alive
+        mock_process1.terminate = Mock()
+        mock_process1.wait = Mock()
+
+        mock_process2 = Mock()
+        mock_process2.pid = 5678
+        mock_process2.poll.return_value = 0  # Process is already dead
+
+        mock_process3 = Mock()
+        mock_process3.pid = 9012
+        mock_process3.poll.return_value = None  # Process is alive
+        mock_process3.terminate = Mock(side_effect=Exception("Terminate failed"))
+        mock_process3.kill = Mock()
+        mock_process3.wait = Mock()
+
+        # Set up worker processes and configs
+        cluster_manager._worker_processes = [
+            mock_process1,
+            mock_process2,
+            mock_process3,
+        ]
+        cluster_manager._worker_configs = [
+            {"node_name": "worker-1"},
+            {"node_name": "worker-2"},
+            {"node_name": "worker-3"},
+        ]
+
+        with (
+            patch("asyncio.get_running_loop") as mock_loop,
+            patch("asyncio.wait_for") as mock_wait_for,
+        ):
+            mock_loop.return_value = asyncio.get_running_loop()
+            mock_wait_for.return_value = None  # Simulate successful waits
+
+            results = await cluster_manager._stop_all_workers()
+
+            assert len(results) == 3
+
+            # First worker should stop gracefully
+            assert results[0]["status"] == "stopped"
+            assert results[0]["node_name"] == "worker-1"
+            assert "stopped gracefully" in results[0]["message"]
+
+            # Second worker was already stopped
+            assert results[1]["status"] == "stopped"
+            assert results[1]["node_name"] == "worker-2"
+            assert "already stopped" in results[1]["message"]
+
+            # Third worker should have error but still be cleaned up
+            assert results[2]["status"] == "error"
+            assert results[2]["node_name"] == "worker-3"
+            assert "Error stopping worker" in results[2]["message"]
+
+            # Verify worker tracking is cleared
+            assert len(cluster_manager._worker_processes) == 0
+            assert len(cluster_manager._worker_configs) == 0
+
+    @pytest.mark.asyncio
     async def test_job_manager_client_lifecycle(self):
         """Test job manager handles client lifecycle correctly."""
         state_manager = Mock()


### PR DESCRIPTION
Fixes #140

- Simplified _safely_terminate_process method with cleaner logic
- Ensures wait() is always called after terminate() to prevent zombies
- Added proper exception handling to guarantee process cleanup
- Added comprehensive tests for error scenarios and timeout handling
- Removed overly complex nested try-catch blocks for better maintainability

The fix ensures that even when exceptions occur during worker termination, the process cleanup is properly handled to prevent zombie processes from accumulating over time.